### PR TITLE
Re-enabled uglify

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ let conf = {
   externals: Object.keys( pkg.dependencies ),
 
   plugins: [
+    isProd ? new UglifyJSPlugin() : null,
     isProfile ? new BundleAnalyzerPlugin() : null,
 
     new webpack.EnvironmentPlugin(['NODE_ENV'])


### PR DESCRIPTION
When I was doing a build, I noticed that JS compression was broken. This re-enables it for production builds. Drops bundled file size from 94.8kb to 12.6kb.